### PR TITLE
Optimize parser

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -25,7 +25,10 @@ class queryParser{
 		
 		// Are we currently seeking new delimiter
 		this.seekingDelimiter = false;
-		
+
+		// Does the sql set change delimiter?
+                this.hasDelimiter = queriesString.includes('DELIMITER ');
+
 		// Iterate over each char in the string
 		for (let i = 0; i < this.queriesString.length; i++) {
 			let char = this.queriesString[i];
@@ -37,7 +40,11 @@ class queryParser{
 	parseChar(char){
 		this.checkEscapeChar();
 		this.buffer.push(char);
-		this.checkNewDelimiter(char);
+
+		if (this.hasDelimiter) {
+		  this.checkNewDelimiter(char);
+		}
+
 		this.checkQuote(char);
 		this.checkEndOfQuery();
 	}

--- a/src/parser.js
+++ b/src/parser.js
@@ -27,7 +27,7 @@ class queryParser{
 		this.seekingDelimiter = false;
 
 		// Does the sql set change delimiter?
-                this.hasDelimiter = queriesString.includes('DELIMITER ');
+		this.hasDelimiter = queriesString.toLowerCase().includes('delimiter ');
 
 		// Iterate over each char in the string
 		for (let i = 0; i < this.queriesString.length; i++) {
@@ -42,7 +42,7 @@ class queryParser{
 		this.buffer.push(char);
 
 		if (this.hasDelimiter) {
-		  this.checkNewDelimiter(char);
+			this.checkNewDelimiter(char);
 		}
 
 		this.checkQuote(char);


### PR DESCRIPTION
Currently checkNewDelimiter() might take most of the parser's processing time on joining buffer.

Suggestion is to skip this step if the SQL does not include `DELIMITER` clause.