### PR TITLE
Performance improvements

### DIFF
--- a/mysql-import.js
+++ b/mysql-import.js
@@ -485,7 +485,8 @@ class queryParser extends stream.Writable{
 	
 	// Check to see if a new delimiter is being assigned
 	checkNewDelimiter(char){
-		var buffer_str = this.buffer.join('').toLowerCase().trim();
+		var buffer_str = '';
+    		if (this.buffer.length < 10) buffer_str = this.buffer.join('').toLowerCase().trim();
 		if(buffer_str === 'delimiter' && !this.quoteType){
 			this.seekingDelimiter = true;
 			this.buffer = [];


### PR DESCRIPTION
Array join operation becomes very heavy when the array gets bigger. This minor change will significantly improve the performance of large queries.
It reduced the import time of a 2MB WordPress dump file from 3 hours to 3 seconds :)